### PR TITLE
Add variable rollerPort for hasCargo() method.

### DIFF
--- a/Robot2019/src/main/java/frc/robot/RobotMap.java
+++ b/Robot2019/src/main/java/frc/robot/RobotMap.java
@@ -40,7 +40,8 @@ public class RobotMap {
   static PowerDistributionPanel pdp;
   static UsbCamera driveCamera, hatchCamera;
   static VideoSink cameraServer;
-  static int cargoPDPPort;
+
+  final static int cargoPDPPort;
 
   static {
     // Initialize motors on the left side of the drivetrain.
@@ -70,8 +71,8 @@ public class RobotMap {
     hatchCamera = configureCamera(1);
     cameraServer = CameraServer.getInstance().getServer();
     cameraServer.setSource(driveCamera);
-    
-    cargoPDPPort = -1; // Update this with actual PDP channel 
+
+    cargoPDPPort = -1;  // TODO: set ports to actual cargo motor port in pdp
   }
 
   private static WPI_TalonSRX createConfiguredTalon(int port) {

--- a/Robot2019/src/main/java/frc/robot/subsystems/Cargo.java
+++ b/Robot2019/src/main/java/frc/robot/subsystems/Cargo.java
@@ -17,7 +17,7 @@ public class Cargo extends Subsystem {
 
   private VictorSP roller;
   private PowerDistributionPanel pdp;
-  private int rollerPort;   // The port for the VictorSP on the PDP, not the RoboRIO.
+  private int rollerPort; // The port for the VictorSP on the PDP, not the RoboRIO.
 
   public Cargo(VictorSP roller, PowerDistributionPanel pdp, int rollerPort) {
     this.roller = roller;
@@ -39,7 +39,6 @@ public class Cargo extends Subsystem {
 
   public boolean hasCargo() {
     return pdp.getCurrent(rollerPort) > 15;
-    // TODO: set ports to actual cargo motor port
   }
 
   @Override


### PR DESCRIPTION
Fixes issue #17 by having a variable for the PDP port. It does not change automatically so if the VictorSP is assigned to a different port on the PDP, we will have to manually change the value of the rollerPort variable.